### PR TITLE
Use stdin and regular output instead of intermediate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # Repoman
 
-Repoman is a script to export and import a list of git repositories using an intermediate `repoman.lst` file.
+Repoman is a script to export and import a list of git repositories.
 
-When exporting, Repoman scans the working directory for .git folders and save its relative path with the git remote.
+When run, repoman scans the working directory for .git folders and echoes its relative path with the git remote. You can save this into a file.
 
-When importing, repoman will restore this directory structure and clone each repository.
+When these contents are piped into Repoman, repositories will be cloned into this directory structure.
 
 # Why use this
 
 It's bad practice to use cloud sync solutions to sync working copies (https://git.seveas.net/how-to-back-up-a-git-repository.html).
 
-Repoman helps you work on the same projects on multiple devices, by syncing `repoman.lst` instead.
+Repoman helps you work on the same projects on multiple devices, by syncing an intermediate file.
 
 # Examples
 
 Export:
 ```bash
-$ repoman.sh export
+$ repoman.sh | tee repoman.lst
 vagrant.local=https://github.com/Chassis/Chassis.git
 vagrant.local/content/plugins/404-fallback=https://github.com/svandragt/404-fallback.git
 Taskfile=git@github.com:svandragt/Taskfile.git
@@ -27,7 +27,7 @@ repoman=https://github.com/svandragt/repoman.git
 Import:
 
 ```bash
-$ repoman.sh import
+$ cat repoman.lst | repoman.sh
 
 ⏳ Cloning vagrant.local
 Cloning into 'vagrant.local'...

--- a/repoman.sh
+++ b/repoman.sh
@@ -1,28 +1,7 @@
 #!/usr/bin/env bash
-FILE=repoman.lst
 INVOKE_DIR=${PWD}/
 
-help() {
-	ME=`basename "$0"`
-	cat << EOF
-usage: $ME <option>
-
-This script exports and imports git repos found at the current location.
-
-OPTIONS:
-   export  Write git repos into $FILE
-   import  Clone git repos from $FILE
-   help    This message
-EOF
-}
-
-
-export() {
-	if [[ -f "$FILE" ]]; then
-	    echo "⚠️ Error: $FILE exists! Please remove the file before exporting."
-	    exit 1
-	fi
-
+_export() {
 	while read -r d
 	do
 	    pushd "$d/.." >/dev/null
@@ -34,25 +13,25 @@ export() {
 	      continue
 	    fi
 
-	    echo "$PRJ_DIR=$REMOTE" | tee -a $FILE
+	    echo "$PRJ_DIR=$REMOTE"
 	done < <(find . -type d -name '.git' -follow)	
 }
 
-import() {
-	if [[ ! -f "$FILE" ]]; then
-	    echo "⚠️ Error: $FILE does not exists! Please copy it here before importing."
-	    exit 1
-	fi
-
+_import() {
 	while read line
 	do
 		IFS='=' read PRJ_DIR REMOTE <<< "$line"
 		
 	    echo; echo "⏳ Cloning $PRJ_DIR"
 	    git clone $REMOTE $PRJ_DIR
-	done < repoman.lst
+	done < "${1:-/dev/stdin}"
 }
 
 
-CB=$1; CB=${CB:=help}
-$CB
+if [ -t 0 ]; then
+	# tty	
+    _export
+else 
+	# no tty
+    _import
+fi


### PR DESCRIPTION
Using import and export parameters is cumbersome, as the intermedia file still needs to be copied or moved into position for syncing.Therefor repoman now uses stdout and stdin, giving the user control over the output and input. For example, choosing the location of the intermediate file. Or excluding certain lines via grep -v.